### PR TITLE
Change Cron to be workable with Jeedom 4.4.8

### DIFF
--- a/core/class/AndroidTV.class.php
+++ b/core/class/AndroidTV.class.php
@@ -83,7 +83,7 @@ class AndroidTV extends eqLogic{
 			$cron->setOption(array('id' => $this->getId()));
 			$cron->setEnable(1);
 			$cron->setTimeout('1');
-			$cron->setSchedule('* * * * * *');
+			$cron->setSchedule('* * * * *');
 			$cron->save();
 		}
 		$cron->start();


### PR DESCRIPTION
Jeedom support standard Cron with 5 *, not 6